### PR TITLE
Fix dependencies of neo4j in poms

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -489,6 +489,30 @@
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-cell</artifactId>
             <version>${solr.client.version}</version>
+            <exclusions>
+                <!-- More recent version in neo4j [START]-->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <!-- More recent version in neo4j [END]-->
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -658,6 +682,13 @@
             <groupId>com.opencsv</groupId>
             <artifactId>opencsv</artifactId>
             <version>4.5</version>
+            <exclusions>
+                <!-- More recent version in neo4j -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Email templating -->
@@ -686,18 +717,19 @@
             <artifactId>bcel</artifactId>
             <version>6.4.0</version>
         </dependency>
-        
+
         <dependency>
-        	<groupId>org.neo4j</groupId>
-        	<artifactId>neo4j</artifactId>
-        	<version>4.0.1</version>
+            <groupId>org.neo4j</groupId>
+            <artifactId>neo4j</artifactId>
+            <version>4.0.3</version>
         </dependency>
-        
-		<dependency>
-		    <groupId>org.neo4j.driver</groupId>
-		    <artifactId>neo4j-java-driver</artifactId>
-		    <version>4.0.0</version>
-		</dependency>
+
+        <dependency>
+	        <groupId>org.neo4j.driver</groupId>
+	        <artifactId>neo4j-java-driver</artifactId>
+	        <version>4.0.0</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/dspace-oai/pom.xml
+++ b/dspace-oai/pom.xml
@@ -152,6 +152,11 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-configuration-processor</artifactId>
                 </exclusion>
+                <!-- More recent version in neo4j -->
+                <exclusion>
+                    <groupId>org.parboiled</groupId>
+                    <artifactId>parboiled-java</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -261,7 +266,7 @@
         <dependency>
             <groupId>org.parboiled</groupId>
             <artifactId>parboiled-core</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/dspace-server-webapp/pom.xml
+++ b/dspace-server-webapp/pom.xml
@@ -428,6 +428,11 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-xml</artifactId>
                 </exclusion>
+                <!-- More recent version in neo4j -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -487,6 +492,28 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-xml</artifactId>
                 </exclusion>
+                <!-- More recent version in neo4j [START]-->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <!-- More recent version in neo4j [END]-->
             </exclusions>
         </dependency>
         <!-- Reminder: Keep icu4j (in Parent POM) synced with version used by lucene-analyzers-icu below,

--- a/dspace/modules/server/pom.xml
+++ b/dspace/modules/server/pom.xml
@@ -283,6 +283,30 @@ just adding new jar in the classloader</description>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-cell</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <!-- More recent version in neo4j [START]-->
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.github.ben-manes.caffeine</groupId>
+                    <artifactId>caffeine</artifactId>
+                </exclusion>
+                <!-- More recent version in neo4j [END]-->
+            </exclusions>
         </dependency>
         <!-- Reminder: Keep icu4j (in Parent POM) synced with version used by lucene-analyzers-icu below,
              otherwise ICUFoldingFilterFactory may throw errors in tests.  -->

--- a/dspace/pom.xml
+++ b/dspace/pom.xml
@@ -285,6 +285,13 @@
             <groupId>org.dspace.modules</groupId>
             <artifactId>additions</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <!-- More recent version in neo4j [START]-->
+                <exclusion>
+                    <groupId>org.apache.xmlbeans</groupId>
+                    <artifactId>xmlbeans</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     	<!-- This dependency ensures DSpace OAI JAR is added to [dspace]/lib/,
              so that the 'dspace oai' launcher.xml command works.  -->

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,8 @@
         <hibernate-validator.version>6.0.17.Final</hibernate-validator.version>
         <!-- PIN Solr to 7.3.x until SOLR-12858 is fixed. This bug affects all integration tests that use Solr
              https://issues.apache.org/jira/browse/SOLR-12858 -->
-        <solr.client.version>7.3.1</solr.client.version>
+        <!--solr.client.version>7.3.1</solr.client.version-->
+        <solr.client.version>8.2.0</solr.client.version>
         <spring.version>5.1.9.RELEASE</spring.version>
         <spring-boot.version>2.1.8.RELEASE</spring-boot.version>
         <!-- Library for reading JSON documents: https://github.com/json-path/JsonPath -->
@@ -1426,6 +1427,13 @@
                 <groupId>org.apache.poi</groupId>
                 <artifactId>poi-ooxml</artifactId>
                 <version>${poi-version}</version>
+                <!-- More recent version in neo4j -->
+                 <exclusions>
+		            <exclusion>
+		                <groupId>org.apache.xmlbeans</groupId>
+		                <artifactId>xmlbeans</artifactId>
+	                </exclusion>
+	            </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Fix a conflict between org.apache.solr:solr:7.3.1 and org.neo4j:neo4j:4.0.3.
The two versions are made homogeneous using Solr version 8.2.0 (see dependencies of neo4j-lucene-index).

### Version updated:
org.apache.commons:commons-compress:1.19
com.github.ben-manes.caffeine:caffeine:2.8.0
org.apache.xmlbeans:xmlbeans:3.0.1
org.parboiled:parboiled-java:1.2.0
org.bouncycastle:bcpkix-jdk15on:1.64
org.bouncycastlebcprov-jdk15on:1.64

### Conficts resolved
org.apache.solr:solr-cell:8.2.0	
> (org.apache.commons:commons-compress:1.18)
> (com.github.ben-manes.caffeine:caffeine:2.4.0)
> (org.apache.xmlbeans:xmlbeans:3.0.1)
> (org.apache.commons:commons-text:1.6)
> (com.github.ben-manes.caffeine:caffeine:2.4.0)
> (org.bouncycastle:bcpkix-jdk15on:1.60)
> (org.bouncycastlebcprov-jdk15on:1.60)

org.apache.solr:solr-cell:8.2.0
> (org.apache.commons:commons-text:1.6)

org.apache.solr:solr-core:8.2.0
> (org.apache.commons:commons-text:1.6)

org.neo4j:neo4j:4.0.3
> (org.apache.commons:commons-compress:1.19)
> (com.github.ben-manes.caffeine:caffeine:2.8.0)
> (org.parboiled:parboiled-java:1.2.0)
> (org.bouncycastle:bcpkix-jdk15on:1.64)
> (org.bouncycastlebcprov-jdk15on:1.64)
> (org.parboiled:parboiled-java:1.2.0)

org.apache.poi:poi-ooxml:3.17
> (org.apache.xmlbeans:xmlbeans:2.6.0)

org.jtwig:jtwig-spring-boot-starter:5.87.0.RELEASE
> (org.parboiled:parboiled-java:1.1.7)
