### PR TITLE
Fix dspace deployment

### DIFF
--- a/dspace-api/pom.xml
+++ b/dspace-api/pom.xml
@@ -342,6 +342,44 @@
                     <artifactId>asm-commons</artifactId>
                 </exclusion>
                 <!-- neo4j has a more recent version [END]-->
+                <!-- remove all Websocket libraries [START] -->
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-servlet</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>websocket-server</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.websocket</groupId>
+                    <artifactId>javax.websocket-client-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.websocket</groupId>
+                    <artifactId>javax.websocket-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>javax-websocket-client-impl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.websocket</groupId>
+                    <artifactId>javax-websocket-server-impl</artifactId>
+                </exclusion>
+                <!-- remove all Websocket libraries [END] -->
             </exclusions>
         </dependency>
         <dependency>
@@ -753,6 +791,12 @@
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j</artifactId>
             <version>4.0.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-nop</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- neo4j 4.0.3 is recompiled with jetty.version 9.4.19.v20190610 -->
@@ -785,6 +829,35 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-commons</artifactId>
             <version>7.2</version>
+        </dependency>
+
+        <!-- BUG: https://github.com/jtwig/jtwig/issues/367
+            Error: org.springframework.beans.factory.BeanCreationException:
+            Error creating bean with name 'jtwigViewResolver' defined in class path
+            resource [org/jtwig/spring/boot/JtwigAutoConfiguration$JtwigViewResolverConfiguration.class]:
+            Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError:
+            org/parboiled/BaseParser
+
+            @See also neo4j dependencies.
+        -->
+        <dependency>
+            <groupId>org.parboiled</groupId>
+            <artifactId>parboiled-java</artifactId>
+            <version>1.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-tree</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-analysis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/dspace-api/src/main/java/org/dspace/app/batch/ItemImportMainOA.java
+++ b/dspace-api/src/main/java/org/dspace/app/batch/ItemImportMainOA.java
@@ -32,7 +32,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;

--- a/dspace-api/src/main/java/org/dspace/app/batch/ItemImportOA.java
+++ b/dspace-api/src/main/java/org/dspace/app/batch/ItemImportOA.java
@@ -27,7 +27,7 @@ import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.PosixParser;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.authorize.AuthorizeException;
 import org.dspace.authorize.ResourcePolicy;

--- a/dspace-api/src/main/java/org/dspace/content/CitationMetadataUpdateProcessPlugin.java
+++ b/dspace-api/src/main/java/org/dspace/content/CitationMetadataUpdateProcessPlugin.java
@@ -9,7 +9,7 @@ package org.dspace.content;
 
 import java.io.ByteArrayOutputStream;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.dspace.content.crosswalk.StreamDisseminationCrosswalk;
 import org.dspace.content.factory.ContentServiceFactory;

--- a/dspace/config/modules/itemauthority.cfg
+++ b/dspace/config/modules/itemauthority.cfg
@@ -43,4 +43,7 @@ choices.presentation.dc.relation.project = suggest
 authority.controlled.dc.relation.project = true
 cris.ItemAuthority.dc_relation_project.relationshipType = project
  
- 
+choices.plugin.dc.relation.publication = PublicationAuthority
+choices.presentation.dc.relation.publication = suggest
+authority.controlled.dc.relation.publication = true
+cris.ItemAuthority.dc_relation_publication.relationshipType = publication


### PR DESCRIPTION
Removed Websocket dependencies that clash with the Tomcat server.

Fix : "Error creating bean with name 'jtwigViewResolver' defined in class path resource [org/jtwig/spring/boot/JtwigAutoConfiguration$JtwigViewResolverConfiguration.class]: Invocation of init method failed; nested exception is java.lang.NoClassDefFoundError: org/parboiled/BaseParser.

Minor fix on import org.apache.commons.lang.StringUtils, replaced with org.apache.commons.lang3.StringUtils.
