### PR TITLE
Added curate task neo4j

### DIFF
--- a/dspace-api/src/main/java/org/dspace/ctask/neo4j/Neo4jCurationTask.java
+++ b/dspace-api/src/main/java/org/dspace/ctask/neo4j/Neo4jCurationTask.java
@@ -1,0 +1,77 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.ctask.neo4j;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+
+import org.dspace.content.DSpaceObject;
+import org.dspace.content.Item;
+import org.dspace.core.Context;
+import org.dspace.curate.AbstractCurationTask;
+import org.dspace.curate.Curator;
+import org.dspace.curate.Suspendable;
+import org.dspace.neo4j.factory.Neo4jFactory;
+import org.dspace.neo4j.service.Neo4jService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Suspendable(invoked = Curator.Invoked.INTERACTIVE)
+public class Neo4jCurationTask extends AbstractCurationTask {
+
+    private static final Logger log = LoggerFactory.getLogger(Neo4jCurationTask.class);
+    private Neo4jService neo4jService = Neo4jFactory.getInstance().getNeo4jService();
+
+    protected int status = Curator.CURATE_UNSET;
+    protected final String UPDATE_FAILED_MESSAGE = "Updated failed";
+    protected final String UPDATE_SUCCESS_MESSAGE = "Updated successfully in neo4j";
+    protected final String ERROR_MESSAGE = "Error in updating {}, with Handle {} in neo4j";
+    protected final String NEW_ITEM_HANDLE = "in workflow";
+
+    @Override
+    public int perform(DSpaceObject dso) throws IOException {
+        status = Curator.CURATE_SKIP;
+        if (log.isDebugEnabled())
+            log.debug("The target dso is " + dso.getName());
+
+        if (dso instanceof Item) {
+            status = Curator.CURATE_SUCCESS;
+            Item item = (Item) dso;
+            try {
+                Context context = Curator.curationContext();
+
+                neo4jService.insertUpdateItem(context, item.getID());
+            } catch (Exception e) {
+                String message = MessageFormat.format(ERROR_MESSAGE, dso.getID(), getItemHandle(item));
+                setResult(message);
+
+                log.error(message, e);
+                return Curator.CURATE_ERROR;
+            }
+
+            formatResults(item);
+        }
+        return status;
+    }
+
+    protected void formatResults(Item item) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Item: ").append(getItemHandle(item)).append(" ");
+        if (status == Curator.CURATE_FAIL) {
+            sb.append(UPDATE_FAILED_MESSAGE);
+        } else {
+            sb.append(UPDATE_SUCCESS_MESSAGE);
+        }
+        setResult(sb.toString());
+    }
+
+    protected String getItemHandle(Item item) {
+        String handle = item.getHandle();
+        return (handle != null) ? handle : NEW_ITEM_HANDLE;
+    }
+}

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/neo4j/AuthorNGraph.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/model/neo4j/AuthorNGraph.java
@@ -121,8 +121,9 @@ public class AuthorNGraph {
      * 
      * The start the call give the dspaceNode and null as relation.
      * 
-     * @param node     The DSpaceNode object.
-     * @param metadata Metadata used to fill the name
+     * @param node             The DSpaceNode object.
+     * @param metadata         Metadata used to fill the name
+     * @param relationMetadata The metadata used to fill the relation
      * @return The AuthorNGraph object
      * @throws JsonProcessingException
      */
@@ -143,7 +144,8 @@ public class AuthorNGraph {
      * @return The AuthorNGraph object
      * @throws JsonProcessingException
      */
-    static private AuthorNGraph build(DSpaceNode node, DSpaceRelation relation, String metadata, List<String> relationMetadata) {
+    static private AuthorNGraph build(DSpaceNode node, DSpaceRelation relation, String metadata,
+            List<String> relationMetadata) {
         AuthorNGraph authorNGraph = null;
 
         if (node.getRelations() == null || node.getRelations().isEmpty()) {

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/neo4j/Neo4jController.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/neo4j/Neo4jController.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.dspace.app.rest.exception.UnprocessableEntityException;
 import org.dspace.app.rest.model.Neo4jRest;
+import org.dspace.app.rest.model.neo4j.AuthorNGraph;
 import org.dspace.app.rest.neo4j.repository.Neo4jRepository;
 import org.dspace.app.rest.utils.ContextUtil;
 import org.dspace.authorize.AuthorizeException;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -42,7 +44,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class Neo4jController {
 
     @Autowired
-    Neo4jRepository neo4jRepository;
+    private Neo4jRepository neo4jRepository;
 
     /***
      * Insert a DSpaceNode.
@@ -76,10 +78,34 @@ public class Neo4jController {
      */
     @RequestMapping(method = RequestMethod.GET, value = "/dspacenode/{iddb}")
     @PreAuthorize("hasAuthority('AUTHENTICATED')")
-    public DSpaceNode readNodeById(HttpServletRequest request, @PathVariable("iddb") String iddb) throws AuthorizeException {
+    public DSpaceNode readNodeById(HttpServletRequest request, @PathVariable("iddb") String iddb)
+            throws AuthorizeException {
 
         Context context = ContextUtil.obtainContext(request);
 
         return neo4jRepository.readNodeById(context, iddb);
+    }
+
+    /***
+     * Return an AuthorNGraph.
+     * 
+     * @param request          The request
+     * @param iddb             The key
+     * @param depth            The depth of the graph
+     * @param metadata         The Metadata used to fill the name
+     * @param relationMetadata The metadata used to fill the relation
+     * @return The DSpaceNode
+     * @throws AuthorizeException
+     */
+    @RequestMapping(method = RequestMethod.GET, value = "/authorngraph/{iddb}")
+    public AuthorNGraph authorNGraph(HttpServletRequest request, @PathVariable("iddb") String iddb,
+            @RequestParam(value = "depth", required = true) int depth,
+            @RequestParam(value = "metadata", required = true) String metadata,
+            @RequestParam(value = "relationMetadata", required = true) String relationMetadata)
+            throws AuthorizeException {
+
+        Context context = ContextUtil.obtainContext(request);
+
+        return neo4jRepository.authorNGraph(context, iddb, depth, metadata, relationMetadata);
     }
 }

--- a/dspace-server-webapp/src/main/java/org/dspace/app/rest/neo4j/repository/Neo4jRepository.java
+++ b/dspace-server-webapp/src/main/java/org/dspace/app/rest/neo4j/repository/Neo4jRepository.java
@@ -7,7 +7,10 @@
  */
 package org.dspace.app.rest.neo4j.repository;
 
+import java.util.Arrays;
+
 import org.dspace.app.rest.model.Neo4jRest;
+import org.dspace.app.rest.model.neo4j.AuthorNGraph;
 import org.dspace.core.Context;
 import org.dspace.neo4j.DSpaceNode;
 import org.dspace.neo4j.service.Neo4jService;
@@ -44,5 +47,24 @@ public class Neo4jRepository {
         DSpaceNode dspaceNode = neo4jService.readNodeById(context, iddb);
 
         return dspaceNode;
+    }
+
+    /***
+     * 
+     * @param context          The context
+     * @param iddb             The key
+     * @param depth            The depth of the graph
+     * @param metadata         The Metadata used to fill the name
+     * @param relationMetadata The metadata used to fill the relation
+     * @return
+     */
+    public AuthorNGraph authorNGraph(Context context, String iddb, int depth, String metadata,
+            String relationMetadata) {
+        DSpaceNode readFromRes1ById = neo4jService.readNodeById(context, iddb, depth);
+
+        AuthorNGraph authorNGraph = AuthorNGraph.build(readFromRes1ById, metadata,
+                Arrays.asList(relationMetadata.split(",")));
+
+        return authorNGraph;
     }
 }

--- a/dspace/config/modules/curate.cfg
+++ b/dspace/config/modules/curate.cfg
@@ -14,6 +14,7 @@ plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.RequiredM
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.ClamScan = vscan
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MicrosoftTranslator = translate
 plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.general.MetadataValueLinkChecker = checklinks
+plugin.named.org.dspace.curate.CurationTask = org.dspace.ctask.neo4j.Neo4jCurationTask = neo4j
 # add new tasks here (or in additional config files)
 
 ## task queue implementation
@@ -31,13 +32,14 @@ curate.taskqueue.dir = ${dspace.dir}/ctqueues
 curate.ui.tasknames = profileformats = Profile Bitstream Formats
 curate.ui.tasknames = requiredmetadata = Check for Required Metadata
 curate.ui.tasknames = checklinks = Check Links in Metadata
+curate.ui.tasknames = neo4j = Build neo4j entries
 
 # Tasks may be organized into named groups which display together in UI drop-downs
 # curate.ui.taskgroups = \
 #   general = General Purpose Tasks,
 
 # Group membership is defined using comma-separated lists of task names, one property per group
-# curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks
+# curate.ui.taskgroup.general = profileformats, requiredmetadata, checklinks, neo4j
 
 # Name of queue used when tasks queued in Admin UI
 curate.ui.queuename = admin_ui


### PR DESCRIPTION
Added code of curation task related to neo4j. 

Example of a call:
`curate -t neo4j -i 123456789/156`

Added rest call authorngraph, example:
`/api/app/neo4j/authorngraph/<iddb>?depth=5&metadata=dc_contributor_author&relationMetadata=dc_date_issued,dc_coverage_spatial`